### PR TITLE
Support serialisation of class objects

### DIFF
--- a/django_settings_view_as_json.py
+++ b/django_settings_view_as_json.py
@@ -1,5 +1,6 @@
 import copy
 
+from collections import OrderedDict
 from django.views.generic import View
 from braces.views import JSONResponseMixin
 
@@ -53,7 +54,7 @@ class settings_view(JSONResponseMixin, View):
     def get(self, request, *args, **kwargs):
 
         from django.conf import settings
-        data = dict()
+        data = OrderedDict()
 
         for k in dir(settings):
             if k.isupper():

--- a/django_settings_view_as_json.py
+++ b/django_settings_view_as_json.py
@@ -1,5 +1,6 @@
 import copy
 
+import inspect
 from collections import OrderedDict
 from django.views.generic import View
 from braces.views import JSONResponseMixin
@@ -38,9 +39,11 @@ def serialize_function_values(the_dict):
             continue
 
         elif isinstance(val, list):
-            for item in val:
+            for i, item in enumerate(val):
                 if isinstance(item, dict):
                     serialize_function_values(item)
+                elif inspect.isclass(item):
+                    val[i] = repr(item)
 
             continue
 


### PR DESCRIPTION
Handle case that we have a class object as setting value (weird, I know).

eg, fixes this case in 

```
# settings.py

class A(object):
  pass

FOO = [A]
```

I hit this when using django-constance CONSTANCE_ADDITIONAL_FIELDS - see http://django-constance.readthedocs.org/en/latest/#custom-fields

Also, use OrderedDict so JSON is dict order (alphabetical) instead of random order.